### PR TITLE
Fix: Move history display and move navigation logic (#005)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import React, { useState } from "react";
 export default function App() {
   const [moveHistory, setMoveHistory] = useState([]);
   const [board, setBoard] = useState(getInitialBoard);
+  const [turn, setTurn] = useState("white");
+  const [curMoveIndex, setCurMoveIndex] = useState(-1);
 
   return (
     <>
@@ -16,14 +18,19 @@ export default function App() {
             setBoard={setBoard}
             moveHistory={moveHistory}
             setMoveHistory={setMoveHistory}
+            setTurn={setTurn}
+            turn={turn}
+            curMoveIndex={curMoveIndex}
+            setCurMoveIndex={setCurMoveIndex}
           />
         </div>
         <div className="grid grid-cols-2">
           <div className="flex p-4">
             <MoveHistory
               moveHistory={moveHistory}
-              board={board}
               setBoard={setBoard}
+              setTurn={setTurn}
+              setCurMoveIndex={setCurMoveIndex}
             />
           </div>
           <div></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,9 +10,9 @@ export default function App() {
 
   return (
     <>
-      <div className="grid grid-cols-3 min-h-screen">
+      <div className="grid grid-cols-[1fr_400px_1fr] grid-rows-[1fr_400px_1fr] min-h-screen">
         <div></div>
-        <div className="flex justify-center items-center">
+        <div className="flex justify-center col-2 row-2 content-center items-center">
           <Board
             board={board}
             setBoard={setBoard}
@@ -24,8 +24,8 @@ export default function App() {
             setCurMoveIndex={setCurMoveIndex}
           />
         </div>
-        <div className="grid grid-cols-2">
-          <div className="flex p-4">
+        <div className="grid grid-cols-2 col-3 row-2">
+          <div className="flex pl-4">
             <MoveHistory
               moveHistory={moveHistory}
               setBoard={setBoard}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,19 @@
 import { Board, MoveHistory } from "./components/index.jsx";
-import React from "react";
+import React, { useState } from "react";
 
 export default function App() {
+  const [moveHistory, setMoveHistory] = useState([]);
+
   return (
     <>
-      <div className="grid grid-cols-[1fr_auto_1fr] gap-4 min-h-screen">
+      <div className="grid grid-cols-3 min-h-screen">
         <div></div>
-        <div>
-          <Board className="flex justify-center items-center" />
+        <div className="flex justify-center items-center">
+          <Board moveHistory={moveHistory} setMoveHistory={setMoveHistory} />
         </div>
-        <div className="flex pt-4">
-          <div>
-            <MoveHistory />
+        <div className="grid grid-cols-2">
+          <div className="flex p-4">
+            <MoveHistory moveHistory={moveHistory} />
           </div>
           <div></div>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,21 @@
-import { Board, Square } from "./components/index.jsx";
+import { Board, MoveHistory } from "./components/index.jsx";
 import React from "react";
 
 export default function App() {
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <Board />
-    </div>
+    <>
+      <div className="grid grid-cols-[1fr_auto_1fr] gap-4 min-h-screen">
+        <div></div>
+        <div>
+          <Board className="flex justify-center items-center" />
+        </div>
+        <div className="flex pt-4">
+          <div>
+            <MoveHistory />
+          </div>
+          <div></div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,30 @@
 import { Board, MoveHistory } from "./components/index.jsx";
+import { getInitialBoard } from "./components/Board.jsx";
 import React, { useState } from "react";
 
 export default function App() {
   const [moveHistory, setMoveHistory] = useState([]);
+  const [board, setBoard] = useState(getInitialBoard);
 
   return (
     <>
       <div className="grid grid-cols-3 min-h-screen">
         <div></div>
         <div className="flex justify-center items-center">
-          <Board moveHistory={moveHistory} setMoveHistory={setMoveHistory} />
+          <Board
+            board={board}
+            setBoard={setBoard}
+            moveHistory={moveHistory}
+            setMoveHistory={setMoveHistory}
+          />
         </div>
         <div className="grid grid-cols-2">
           <div className="flex p-4">
-            <MoveHistory moveHistory={moveHistory} />
+            <MoveHistory
+              moveHistory={moveHistory}
+              board={board}
+              setBoard={setBoard}
+            />
           </div>
           <div></div>
         </div>

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -49,11 +49,11 @@ function getInitialBoard() {
   return board;
 }
 
-export default function Board() {
+export default function Board({ moveHistory, setMoveHistory }) {
   const [board, setBoard] = useState(getInitialBoard); // board state
   const [selected, setSelected] = useState(null); // selected piece state
   const [turn, setTurn] = useState(COLORS.WHITE); // turn state
-  const [moveHistory, setMoveHistory] = useState([]); // last move info including pawn doubleStep
+  // const [moveHistory, setMoveHistory] = useState([]); // last move info including pawn doubleStep
 
   // move function
   function executeMove(selected, row, col) {
@@ -85,7 +85,7 @@ export default function Board() {
   // when you click a square, you get the row and column of the square
   function handleSquareClick(row, col) {
     // first checking if a piece is selected, to then attempt a move
-    console.log(lastMove);
+    // console.log(lastMove);
 
     // first we check if the selected state is true (if a piece is already selected)
     if (

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -20,7 +20,7 @@ function createPiece(name, color) {
   return piece;
 }
 
-function getInitialBoard() {
+export function getInitialBoard() {
   const board = Array(8)
     .fill(null)
     .map(() => Array(8).fill(null));
@@ -49,8 +49,13 @@ function getInitialBoard() {
   return board;
 }
 
-export default function Board({ moveHistory, setMoveHistory }) {
-  const [board, setBoard] = useState(getInitialBoard); // board state
+export default function Board({
+  moveHistory,
+  setMoveHistory,
+  board,
+  setBoard,
+}) {
+  // const [board, setBoard] = useState(getInitialBoard); // board state
   const [selected, setSelected] = useState(null); // selected piece state
   const [turn, setTurn] = useState(COLORS.WHITE); // turn state
   // const [moveHistory, setMoveHistory] = useState([]); // last move info including pawn doubleStep
@@ -103,9 +108,11 @@ export default function Board({ moveHistory, setMoveHistory }) {
         [row, col] // targetPos
       )
     ) {
+      const newBoard = executeMove(selected, row, col);
       setMoveHistory([
         ...moveHistory,
         {
+          board: newBoard,
           piece: selected.piece,
           fromRow: selected.row,
           fromCol: selected.col,
@@ -117,7 +124,7 @@ export default function Board({ moveHistory, setMoveHistory }) {
         },
       ]);
 
-      setBoard(executeMove(selected, row, col)); // update board with newBoard from executeMove()
+      setBoard(newBoard); // update board with newBoard from executeMove()
       setSelected(null); // deselect everything
       setTurn(turn == COLORS.WHITE ? COLORS.BLACK : COLORS.WHITE); // toggle turn
     } else if (

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -165,7 +165,6 @@ export default function Board({
           ))}
         </div>
       ))}
-      <div>{turn}'s turn.</div>
     </div>
   );
 }

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -54,10 +54,14 @@ export default function Board({
   setMoveHistory,
   board,
   setBoard,
+  turn,
+  setTurn,
+  curMoveIndex,
+  setCurMoveIndex,
 }) {
   // const [board, setBoard] = useState(getInitialBoard); // board state
   const [selected, setSelected] = useState(null); // selected piece state
-  const [turn, setTurn] = useState(COLORS.WHITE); // turn state
+  // const [turn, setTurn] = useState(COLORS.WHITE); // turn state
   // const [moveHistory, setMoveHistory] = useState([]); // last move info including pawn doubleStep
 
   // move function
@@ -109,21 +113,29 @@ export default function Board({
       )
     ) {
       const newBoard = executeMove(selected, row, col);
-      setMoveHistory([
-        ...moveHistory,
-        {
-          board: newBoard,
-          piece: selected.piece,
-          fromRow: selected.row,
-          fromCol: selected.col,
-          toRow: row,
-          toCol: col,
-          doubleStep:
-            selected.piece.name == PIECES.PAWN &&
-            Math.abs(selected.row - row) == 2,
-        },
-      ]);
+      let newMoveHistory;
 
+      if (curMoveIndex == -1) {
+        newMoveHistory = [...moveHistory];
+      } else {
+        newMoveHistory = moveHistory.slice(0, curMoveIndex + 1);
+      }
+
+      newMoveHistory.push({
+        board: newBoard,
+        turn: turn,
+        piece: selected.piece,
+        fromRow: selected.row,
+        fromCol: selected.col,
+        toRow: row,
+        toCol: col,
+        doubleStep:
+          selected.piece.name == PIECES.PAWN &&
+          Math.abs(selected.row - row) == 2,
+      });
+
+      setMoveHistory(newMoveHistory);
+      setCurMoveIndex(-1);
       setBoard(newBoard); // update board with newBoard from executeMove()
       setSelected(null); // deselect everything
       setTurn(turn == COLORS.WHITE ? COLORS.BLACK : COLORS.WHITE); // toggle turn

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -1,6 +1,40 @@
 import React from "react";
-import Board from "./Board";
 
-export default function MoveHistory() {
-  return <div>Location Test</div>;
+const notations = {
+  pawn: "",
+  rook: "R",
+  knight: "N",
+  bishop: "B",
+  queen: "Q",
+  king: "K",
+};
+
+export default function MoveHistory({ moveHistory }) {
+  console.log(moveHistory);
+
+  const movePairs = [];
+  for (let i = 0; i < moveHistory.length; i += 2) {
+    const whiteMove = moveHistory[i];
+    const blackMove = moveHistory[i + 1];
+    movePairs.push([whiteMove, blackMove]);
+  }
+
+  return (
+    <div>
+      <h3>Move History</h3>
+      <div>
+        {movePairs.map((pair, index) => (
+          <div key={index} className="flex justify-between">
+            <button className="flex-1 pl-2 pr-2">
+              {index + 1}. {notations[pair[0].piece.name]}
+              {pair[0].toRow}
+            </button>
+            <button className="pl-2 pr-2">
+              {pair[1] ? `${index + 1}. ${notations[pair[1].piece.name]}` : ""}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -44,14 +44,21 @@ export default function MoveHistory({
 
   return (
     <div>
-      <h3>Move History</h3>
+      <div className="grid grid-cols-[30px_5px_75px_75px]">
+        <h3 className="col-span-4 bg-[#faf0d4] border-b-2 border-color-[#faf0d4] text-center font-bold">
+          Move History
+        </h3>
+      </div>
       <div>
         {movePairs.map((pair, index) => (
-          <div key={index} className="grid grid-cols-[30px_5px_75px_75px]">
+          <div
+            key={index}
+            className="grid grid-cols-[30px_5px_75px_75px] bg-[#faf0d4]"
+          >
             <div className=" border-b-2 border-r-2 border-color-[#303030] pl-1 text-left font-bold text-[#303030]">
               {index + 1}.
             </div>
-            <div></div>
+            <div className="border-b-2 border-color-[#303030]"></div>
             <button
               onClick={() => handleClick(index, 0)}
               className="bg-[#faf0d4] text-[#303030] font-bold

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import Board from "./Board";
+
+export default function MoveHistory() {
+  return <div>Location Test</div>;
+}

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -35,17 +35,20 @@ export default function MoveHistory({ moveHistory }) {
       <h3>Move History</h3>
       <div>
         {movePairs.map((pair, index) => (
-          <div key={index} className="flex justify-between">
-            <button className="flex-1 pl-2 pr-2">
-              {index + 1}. {notations[pair[0].piece.name]}
+          <div key={index} className="grid grid-cols-[30px_60px_60px]">
+            <div className="border border-blue-300 pl-1 text-left">
+              {index + 1}.
+            </div>
+            <button className="border border-green-300 text-left pl-2">
+              {notations[pair[0].piece.name]}
               {cols[pair[0].toCol]}
               {pair[0].toRow}
             </button>
-            <button className="pl-2 pr-2">
+            <button className="border border-red-300 text-left pl-2 pr-1">
               {pair[1]
-                ? `${index + 1}. ${notations[pair[1].piece.name]}${
-                    cols[pair[1].toCol]
-                  }${pair[1].toRow}`
+                ? `${notations[pair[1].piece.name]}${cols[pair[1].toCol]}${
+                    pair[1].toRow
+                  }`
                 : ""}
             </button>
           </div>

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -20,6 +20,17 @@ const cols = {
   7: "h",
 };
 
+const rows = {
+  0: "8",
+  1: "7",
+  2: "6",
+  3: "5",
+  4: "4",
+  5: "3",
+  6: "2",
+  7: "1",
+};
+
 export default function MoveHistory({
   moveHistory,
   setBoard,
@@ -66,7 +77,7 @@ export default function MoveHistory({
             >
               {notations[pair[0].piece.name]}
               {cols[pair[0].toCol]}
-              {pair[0].toRow}
+              {rows[pair[0].toRow]}
             </button>
             <button
               onClick={() => handleClick(index, 1)}
@@ -75,7 +86,7 @@ export default function MoveHistory({
             >
               {pair[1]
                 ? `${notations[pair[1].piece.name]}${cols[pair[1].toCol]}${
-                    pair[1].toRow
+                    rows[pair[1].toRow]
                   }`
                 : ""}
             </button>

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -20,8 +20,13 @@ const cols = {
   7: "h",
 };
 
-export default function MoveHistory({ moveHistory }) {
+export default function MoveHistory({ moveHistory, setBoard, board }) {
   console.log(moveHistory);
+
+  function handleClick(pairIndex, moveIndex) {
+    const actualIndex = pairIndex * 2 + moveIndex;
+    setBoard(moveHistory[actualIndex].board);
+  }
 
   const movePairs = [];
   for (let i = 0; i < moveHistory.length; i += 2) {
@@ -39,12 +44,18 @@ export default function MoveHistory({ moveHistory }) {
             <div className="border border-blue-300 pl-1 text-left">
               {index + 1}.
             </div>
-            <button className="border border-green-300 text-left pl-2">
+            <button
+              onClick={() => handleClick(index, 0)}
+              className="border border-green-300 text-left pl-2"
+            >
               {notations[pair[0].piece.name]}
               {cols[pair[0].toCol]}
               {pair[0].toRow}
             </button>
-            <button className="border border-red-300 text-left pl-2 pr-1">
+            <button
+              onClick={() => handleClick(index, 1)}
+              className="border border-red-300 text-left pl-2 pr-1"
+            >
               {pair[1]
                 ? `${notations[pair[1].piece.name]}${cols[pair[1].toCol]}${
                     pair[1].toRow

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -47,13 +47,15 @@ export default function MoveHistory({
       <h3>Move History</h3>
       <div>
         {movePairs.map((pair, index) => (
-          <div key={index} className="grid grid-cols-[30px_60px_60px]">
-            <div className="border border-blue-300 pl-1 text-left">
+          <div key={index} className="grid grid-cols-[30px_5px_75px_75px]">
+            <div className=" border-b-2 border-r-2 border-color-[#303030] pl-1 text-left font-bold text-[#303030]">
               {index + 1}.
             </div>
+            <div></div>
             <button
               onClick={() => handleClick(index, 0)}
-              className="border border-green-300 text-left pl-2"
+              className="bg-[#faf0d4] text-[#303030] font-bold
+              text-left pl-2 border-b-2 border-color-[#303030]"
             >
               {notations[pair[0].piece.name]}
               {cols[pair[0].toCol]}
@@ -61,7 +63,8 @@ export default function MoveHistory({
             </button>
             <button
               onClick={() => handleClick(index, 1)}
-              className="border border-red-300 text-left pl-2 pr-1"
+              className="bg-[#303030] text-[#faf0d4] font-bold text-left 
+              pl-2 pr-1 border-b-2 border-color-[#faf0d4]"
             >
               {pair[1]
                 ? `${notations[pair[1].piece.name]}${cols[pair[1].toCol]}${

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -9,6 +9,17 @@ const notations = {
   king: "K",
 };
 
+const cols = {
+  0: "a",
+  1: "b",
+  2: "c",
+  3: "d",
+  4: "e",
+  5: "f",
+  6: "g",
+  7: "h",
+};
+
 export default function MoveHistory({ moveHistory }) {
   console.log(moveHistory);
 
@@ -27,10 +38,15 @@ export default function MoveHistory({ moveHistory }) {
           <div key={index} className="flex justify-between">
             <button className="flex-1 pl-2 pr-2">
               {index + 1}. {notations[pair[0].piece.name]}
+              {cols[pair[0].toCol]}
               {pair[0].toRow}
             </button>
             <button className="pl-2 pr-2">
-              {pair[1] ? `${index + 1}. ${notations[pair[1].piece.name]}` : ""}
+              {pair[1]
+                ? `${index + 1}. ${notations[pair[1].piece.name]}${
+                    cols[pair[1].toCol]
+                  }${pair[1].toRow}`
+                : ""}
             </button>
           </div>
         ))}

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -20,12 +20,19 @@ const cols = {
   7: "h",
 };
 
-export default function MoveHistory({ moveHistory, setBoard, board }) {
+export default function MoveHistory({
+  moveHistory,
+  setBoard,
+  setTurn,
+  setCurMoveIndex,
+}) {
   console.log(moveHistory);
 
   function handleClick(pairIndex, moveIndex) {
     const actualIndex = pairIndex * 2 + moveIndex;
     setBoard(moveHistory[actualIndex].board);
+    setTurn(moveHistory[actualIndex].turn == "black" ? "white" : "black");
+    setCurMoveIndex(actualIndex);
   }
 
   const movePairs = [];

--- a/src/components/MoveHistory.jsx
+++ b/src/components/MoveHistory.jsx
@@ -62,7 +62,7 @@ export default function MoveHistory({
             <button
               onClick={() => handleClick(index, 0)}
               className="bg-[#faf0d4] text-[#303030] font-bold
-              text-left pl-2 border-b-2 border-color-[#303030]"
+              text-left border-b-2 border-color-[#303030]"
             >
               {notations[pair[0].piece.name]}
               {cols[pair[0].toCol]}
@@ -71,7 +71,7 @@ export default function MoveHistory({
             <button
               onClick={() => handleClick(index, 1)}
               className="bg-[#303030] text-[#faf0d4] font-bold text-left 
-              pl-2 pr-1 border-b-2 border-color-[#faf0d4]"
+              pl-[7px] pr-1 "
             >
               {pair[1]
                 ? `${notations[pair[1].piece.name]}${cols[pair[1].toCol]}${

--- a/src/components/Square.jsx
+++ b/src/components/Square.jsx
@@ -11,7 +11,7 @@ export default function Square({ row, col, piece, highlighted, onClick }) {
   return (
     <div
       className={`w-[50px] h-[50px] ${color} ${
-        highlighted ? "border-4 border-yellow-400" : ""
+        highlighted ? "bg-[#fce174]" : ""
       }`}
       onClick={onClick}
     >

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -1,3 +1,4 @@
 export { default as Board } from "./Board";
 export { default as Square } from "./Square";
 export { default as Piece } from "./Piece";
+export { default as MoveHistory } from "./MoveHistory";


### PR DESCRIPTION
## Description
- Fixed grid layout for move history
- Redid main app grid and row layout for better scalability for more features later on
- Added chess piece notation mapping to show abbreviated moves in move history
- Added rows and columns notation mapping to show proper chess rows and columns for 1-8 and a-h

Closes #005